### PR TITLE
Abort requests when modal closed

### DIFF
--- a/src/components/data-vis/WtLineGraph.tsx
+++ b/src/components/data-vis/WtLineGraph.tsx
@@ -10,14 +10,15 @@ import {
   getLineGraphData,
   getTrendPeriods,
 } from "./lineGraph.util";
-import useGetData from "../../hooks/getData";
 import { Serie } from "@nivo/line";
 import { DateContext } from "../../providers/DateProvider";
+import useGetData from "../../hooks/getData";
 
 const WtLineGraph = ({
   reportDefinition,
   dimensions = [],
   config = {},
+  requestControllersCallback,
   ...props
 }: WtLineGraphProps) => {
   const { wtStartDate, wtEndDate } = React.useContext(DateContext);
@@ -30,11 +31,15 @@ const WtLineGraph = ({
     getTrendPeriods({ wtStartPeriod: wtStartDate, wtEndPeriod: wtEndDate })
   );
   const [lineGraphData, setLineGraphData] = useState<Serie[]>([]);
-
   const [graphOptions, setGraphOptions] = useState({
     ...defaultGraphOptions,
     ...config,
   });
+  const { cancelAllRequests, getWtData } = useGetData();
+
+  if (requestControllersCallback) {
+    requestControllersCallback(cancelAllRequests);
+  }
 
   // Generate search string from Dimensions
   useEffect(() => {
@@ -54,8 +59,6 @@ const WtLineGraph = ({
       getTrendPeriods({ wtStartPeriod: wtStartDate, wtEndPeriod: wtEndDate })
     );
   }, [reportDefinition]);
-
-  const { response, loading, error, status, getWtData } = useGetData();
 
   const sortByDate = async (data: any[]) => {
     return data.sort((a: any, b: any) => {
@@ -190,6 +193,10 @@ interface WtLineGraphProps {
    * https://nivo.rocks/line/
    */
   config?: WtLineProps;
+  /**
+   * cancelAllRequests function from useGetData
+   */
+  requestControllersCallback?: (cancelAllRequests: any) => void;
 }
 
 export default WtLineGraph;

--- a/src/components/reports/ReportModal.tsx
+++ b/src/components/reports/ReportModal.tsx
@@ -16,13 +16,13 @@ import { GridOptions, RowNode } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import WtDataTable from "../data-vis/WtDataTable";
 import WtLineGraph from "../data-vis/WtLineGraph";
-import useGetData from "../../hooks/getData";
 import {
   WtLineProps,
   ProfileProps,
   ProfileReportsProps,
 } from "../../interfaces/interfaces";
 import { DateContext } from "../../providers/DateProvider";
+import useGetData from "../../hooks/getData";
 
 const BootstrapDialog = styled(Dialog)(({ theme }) => ({
   "& .MuiDialogContent-root": {
@@ -64,6 +64,7 @@ const ReportModal = ({
   report,
   tableConfig = {},
   graphConfig = {},
+  cancelRequestsCallback: requestControllersCallback,
   ...props
 }: ReportModalProps) => {
   const { wtStartDate, wtEndDate } = React.useContext(DateContext);
@@ -71,16 +72,14 @@ const ReportModal = ({
   const [gridRef, setGridRef] =
     React.useState<React.RefObject<AgGridReact<any>>>();
 
-  console.log("Report:", report);
-
-  // Get report info
+  const { response: data, loading, getWtData: getReport } = useGetData();
   const {
     response: reportDefinition,
     loading: loadingDefinition,
-    // error,
-    // status,
     getReportDefinition,
   } = useGetData();
+
+  console.log("Report:", report);
 
   React.useEffect(() => {
     if (!report) return;
@@ -90,15 +89,6 @@ const ReportModal = ({
     });
   }, [getReportDefinition, profile, report]);
   console.log("Report info:", reportDefinition);
-
-  // Get report data
-  const {
-    response: data,
-    loading,
-    // error,
-    // status,
-    getWtData: getReport,
-  } = useGetData();
 
   React.useEffect(() => {
     if (!report) return;
@@ -168,6 +158,7 @@ const ReportModal = ({
                   reportDefinition={reportDefinition}
                   dimensions={gridDimensions}
                   config={graphConfig}
+                  requestControllersCallback={requestControllersCallback}
                 />
               </Paper>
             )}
@@ -236,6 +227,10 @@ interface ReportModalProps {
    * https://nivo.rocks/line/
    */
   graphConfig?: WtLineProps;
+  /**
+   * cancelAllRequests function from useGetData
+   */
+  cancelRequestsCallback?: (cancelAllRequests: any) => void;
 }
 
 export default ReportModal;

--- a/src/hooks/getData.tsx
+++ b/src/hooks/getData.tsx
@@ -14,11 +14,14 @@ const useGetData = () => {
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState("");
   const [status, setStatus] = React.useState(200);
+  const [controllers, setControllers] = React.useState<AbortController[]>([]);
 
   const getAxios = async (url: string, params: any) => {
     try {
       const urlParams = { ...params, format: "json" };
 
+      const axiosController = new AbortController();
+      setControllers((prev: any) => [...prev, axiosController]);
       setLoading(true);
       const res = await axios.get(url, {
         params: urlParams,
@@ -26,6 +29,7 @@ const useGetData = () => {
           username: WT_DX_USERNAME || "",
           password: WT_DX_PASSWORD || "",
         },
+        signal: axiosController.signal,
       });
       setResponse(res.data);
       setStatus(res.status);
@@ -73,14 +77,23 @@ const useGetData = () => {
     []
   );
 
+  const cancelAllRequests = React.useCallback(() => {
+    controllers?.forEach((controller) => {
+      controller.abort();
+      console.log("Aborting:", controller);
+    });
+  }, [controllers]);
+
   return {
     response,
     loading,
     error,
     status,
+    controllers,
     getWtData,
     getReportDefinition,
     getKeyMetrics,
+    cancelAllRequests,
   };
 };
 

--- a/src/pages/KeyMetrics.tsx
+++ b/src/pages/KeyMetrics.tsx
@@ -11,11 +11,17 @@ const KeyMetrics = ({ profile }: KeyMetricsPageProps) => {
   const [selectedReport, setSelectedReport] =
     React.useState<ProfileReportsProps | null>(null);
 
+  const cancelApiRequests: any = React.useRef();
+  const getCancelRequests = (cancelAllRequests: any) => {
+    cancelApiRequests.current = cancelAllRequests;
+  };
+
   const handleReportModalOpen = () => {
     setIsReportModalOpen(true);
   };
 
   const handleReportModalClose = () => {
+    cancelApiRequests.current();
     setSelectedReport(null);
     setIsReportModalOpen(false);
   };
@@ -41,6 +47,7 @@ const KeyMetrics = ({ profile }: KeyMetricsPageProps) => {
           onClose={handleReportModalClose}
           profile={profile}
           report={selectedReport}
+          cancelRequestsCallback={getCancelRequests}
         />
       )}
     </Box>


### PR DESCRIPTION
Added cancelAllRequests function to useGetData that is called on report modal close